### PR TITLE
Allow using custom alert commands

### DIFF
--- a/src/main/java/net/climaxmc/autokiller/AutoKiller.java
+++ b/src/main/java/net/climaxmc/autokiller/AutoKiller.java
@@ -57,9 +57,16 @@ public class AutoKiller extends JavaPlugin {
     			.replace("%vl%", vl + "");
     	alert = ChatColor.translateAlternateColorCodes('&', alert);
 
-        for (Player players : Bukkit.getOnlinePlayers()) {
-            if (players.isOp() || players.hasPermission("autokiller.staff")) {
-                players.sendMessage(alert);                
+        if (config.getCustomCommand()) {
+            String command = config.getAlertCommand()
+                .replace("%player%", player.getName())
+                .replace("%alert%", alert);
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+        } else {
+            for (Player players : Bukkit.getOnlinePlayers()) {
+                if (players.isOp() || players.hasPermission("autokiller.staff")) {
+                    players.sendMessage(alert);                
+                }
             }
         }
         

--- a/src/main/java/net/climaxmc/autokiller/util/Config.java
+++ b/src/main/java/net/climaxmc/autokiller/util/Config.java
@@ -86,6 +86,22 @@ public class Config {
         return (String) config.get("normal-alert");
     }
 
+    public boolean getCustomCommand() {
+        if (config.get("custom-command") == null) {
+            config.set("custom-command", false);
+            saveConfig();
+        }
+        return (boolean) config.get("custom-command");
+    }
+
+    public String getAlertCommand() {
+        if (config.get("alert-command") == null) {
+            config.set("alert-command", "");
+            saveConfig();
+        }
+        return (String) config.get("alert-command");
+    }
+
     public int getMaxSpeed() {
         if (config.get("click-speed.max-speed") == null) {
             config.set("click-speed.max-speed", 16);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,12 @@ ban-command: "ban %player% &6AutoKiller &f» &cUnfair Advantage"
 clickspeed-alert: "&8[&6AutoKiller&8] &c%player% &8[&e%ping%ms&8] &7is suspected for &c%cheat% &8[&b%vl% cps&8]"
 normal-alert: "&8[&6AutoKiller&8] &c%player% &8[&e%ping%ms&8] &7is suspected for &c%cheat% &7VL:%vl%"
 
+# Should alerts use a custom command?
+custom-command: false
+# The custom command alerts will use
+# Placeholders: %player%, %alert%
+alert-command: ""
+
 click-speed:
   vl-to-alert: 8
   vl-to-ban: 30


### PR DESCRIPTION
This PR adds the ability for a custom command to be executed when a cheat alert is logged, which replaces the default AK alert.

<details><summary>Example for Cheaty</summary>

For use with current Cheaty, you'd either use:
```yml
# Should alerts use a custom command?
custom-command: true
# The custom command alerts will use
# Placeholders: %player%, %alert%
alert-command: "cheaty notify %alert%"
```
or, if you removed %player% from the alert message:
```yml
# Should alerts use a custom command?
custom-command: true
# The custom command alerts will use
# Placeholders: %player%, %alert%
alert-command: "cheaty notify %player% %alert%"
```

Note: in order for Cheaty to not relay 2 messages on discord, a change might be necessary for it (or the event could be removed here)

</details>